### PR TITLE
Fix/t001 error class name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ TODO
 * Full usage for each resource
 * Proper explanation of the `AfterbanksPSD2:Error` and its subclasses
 
+List of Error
+------------
+
+ *    `1` -> GenericError
+ *   `50` -> IncorrectParametersError (When call API)
+ * `C000` -> GenericConsentError
+ * `C001` -> InvalidConsentError
+ * `C002` -> ConsentWithUnfinalizedProcessError
+ * `C003` -> ProductMismatchConsentError
+ * `C004` -> ExpiredConsentError
+ * `C005` -> MaximumNumberOfCallsReachedConsentError
+ * `T000` -> GenericTransactionError
+ * `T001` -> ConsentNotValidForProductError
+ * `P000` -> Error genérico con la iniciación de pagos.
+
+
+
 About Afterbanks
 ------------
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ List of Error
  * `C004` -> ExpiredConsentError
  * `C005` -> MaximumNumberOfCallsReachedConsentError
  * `T000` -> GenericTransactionError
- * `T001` -> ConsentNotValidForProductError
+ * `T001` -> InvalidConsentForProductError
  * `P000` -> Error genérico con la iniciación de pagos.
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ List of Error
  * `C005` -> MaximumNumberOfCallsReachedConsentError
  * `T000` -> GenericTransactionError
  * `T001` -> InvalidConsentForProductError
- * `P000` -> Error genérico con la iniciación de pagos.
 
 
 

--- a/lib/afterbanks_psd2/base.rb
+++ b/lib/afterbanks_psd2/base.rb
@@ -111,7 +111,7 @@ module AfterbanksPSD2
       when 'T000'
         raise GenericTransactionError.new(**error_info)
       when 'T001'
-        raise ConsentNotValidForProductError.new(**error_info)
+        raise InvalidConsentForProductError.new(**error_info)
       end
 
       nil

--- a/lib/afterbanks_psd2/base.rb
+++ b/lib/afterbanks_psd2/base.rb
@@ -111,7 +111,7 @@ module AfterbanksPSD2
       when 'T000'
         raise GenericTransactionError.new(**error_info)
       when 'T001'
-        raise ProductMismatchTransactionError.new(**error_info)
+        raise ConsentNotValidForProductError.new(**error_info)
       end
 
       nil

--- a/lib/afterbanks_psd2/error.rb
+++ b/lib/afterbanks_psd2/error.rb
@@ -68,7 +68,7 @@ module AfterbanksPSD2
     end
   end
 
-  class ProductMismatchTransactionError < Error
+  class ConsentNotValidForProductError < Error
     def code
       'T001'
     end

--- a/lib/afterbanks_psd2/error.rb
+++ b/lib/afterbanks_psd2/error.rb
@@ -68,7 +68,7 @@ module AfterbanksPSD2
     end
   end
 
-  class ConsentNotValidForProductError < Error
+  class InvalidConsentForProductError < Error
     def code
       'T001'
     end

--- a/spec/afterbanks_psd2/resources/transaction_spec.rb
+++ b/spec/afterbanks_psd2/resources/transaction_spec.rb
@@ -535,9 +535,9 @@ describe AfterbanksPSD2::Transaction do
       context "which is T001 (product mismatch with the consent, transactions variant)" do
         let(:error) { 'T001' }
 
-        it "raises a ProductMismatchTransactionError" do
+        it "raises a ConsentNotValidForProductError" do
           expect { api_call }.to raise_error(
-            an_instance_of(AfterbanksPSD2::ProductMismatchTransactionError)
+            an_instance_of(AfterbanksPSD2::ConsentNotValidForProductError)
               .and having_attributes(
                 code:    'T001',
                 message: "El consentimiento no ha sido creado para el producto solicitado"

--- a/spec/afterbanks_psd2/resources/transaction_spec.rb
+++ b/spec/afterbanks_psd2/resources/transaction_spec.rb
@@ -537,7 +537,7 @@ describe AfterbanksPSD2::Transaction do
 
         it "raises a ConsentNotValidForProductError" do
           expect { api_call }.to raise_error(
-            an_instance_of(AfterbanksPSD2::ConsentNotValidForProductError)
+            an_instance_of(AfterbanksPSD2::InvalidConsentForProductError)
               .and having_attributes(
                 code:    'T001',
                 message: "El consentimiento no ha sido creado para el producto solicitado"

--- a/spec/afterbanks_psd2/resources/transaction_spec.rb
+++ b/spec/afterbanks_psd2/resources/transaction_spec.rb
@@ -535,7 +535,7 @@ describe AfterbanksPSD2::Transaction do
       context "which is T001 (product mismatch with the consent, transactions variant)" do
         let(:error) { 'T001' }
 
-        it "raises a ConsentNotValidForProductError" do
+        it "raises a InvalidConsentForProductError" do
           expect { api_call }.to raise_error(
             an_instance_of(AfterbanksPSD2::InvalidConsentForProductError)
               .and having_attributes(


### PR DESCRIPTION
Rename `ProductMismatchTransactionError` to `InvalidConsentForProductError` 

This involves approaching the Afterbanks message with the code "T001". 