### PR TITLE
Add timeout option to ensure to keep connection for a long request time

### DIFF
--- a/lib/afterbanks_psd2/base.rb
+++ b/lib/afterbanks_psd2/base.rb
@@ -15,7 +15,11 @@ module AfterbanksPSD2
       api_url = ENV['AFTERBANKS_API_URL'] || 'https://apipsd2.afterbanks.com'
       url = api_url + path
 
-      request_params = options.merge!({ method: method, url: url })
+      request_params = { method: method, url: url }
+
+      if options[:timeout]
+        request_params.merge!(timeout: options[:timeout])
+      end
 
       if method == :post
         request_params.merge!(payload: params)

--- a/lib/afterbanks_psd2/base.rb
+++ b/lib/afterbanks_psd2/base.rb
@@ -11,11 +11,11 @@ module AfterbanksPSD2
       yield(configuration)
     end
 
-    def api_call(method:, path:, params: {})
+    def api_call(method:, path:, params: {}, options: {})
       api_url = ENV['AFTERBANKS_API_URL'] || 'https://apipsd2.afterbanks.com'
       url = api_url + path
 
-      request_params = { method: method, url: url }
+      request_params = options.merge!({ method: method, url: url })
 
       if method == :post
         request_params.merge!(payload: params)
@@ -24,7 +24,7 @@ module AfterbanksPSD2
       end
 
       response = begin
-        RestClient::Request.execute(request_params)
+        RestClient::Request.execute(**request_params)
       rescue RestClient::BadRequest, RestClient::ExpectationFailed => bad_request
         # Check
         bad_request.response

--- a/lib/afterbanks_psd2/resources/transaction.rb
+++ b/lib/afterbanks_psd2/resources/transaction.rb
@@ -17,10 +17,18 @@ module AfterbanksPSD2
         startDate:  start_date.strftime("%d-%m-%Y")
       }
 
+      # if the start_date is older than 90 days, we need to increase timeout to 2 hours
+      if start_date < Date.today << 3
+        options = {
+          timeout: 7200
+        }
+      end
+
       response, debug_id = AfterbanksPSD2.api_call(
-        method: :post,
-        path:   '/transactions/',
-        params: params
+        method:  :post,
+        path:    '/transactions/',
+        params:  params,
+        options: options
       )
 
       Response.new(

--- a/spec/afterbanks_psd2/base_spec.rb
+++ b/spec/afterbanks_psd2/base_spec.rb
@@ -65,6 +65,30 @@ describe AfterbanksPSD2 do
 
         api_call
       end
+
+      context "with timeout option" do
+        let(:api_call) {
+          subject.api_call(
+            method:  method, path: path, params: params, options: { timeout: 10 }
+          )
+        }
+
+        it "works" do
+          expect(RestClient::Request)
+            .to receive(:execute)
+                  .with(
+                    method:  :get,
+                    url:     "#{test_api_url}/PSD2/some/endpoint",
+                    headers: {
+                      params: { a: :b, c: :d, e: :f }
+                    },
+                    timeout: 10
+                  )
+                  .and_call_original
+
+          api_call
+        end
+      end
     end
 
     context "for a POST request" do
@@ -106,6 +130,28 @@ describe AfterbanksPSD2 do
                 .and_call_original
 
         api_call
+      end
+
+      context "with timeout option" do
+        let(:api_call) {
+          subject.api_call(
+            method:  method, path: path, params: params, options: { timeout: 10 }
+          )
+        }
+
+        it "works" do
+          expect(RestClient::Request)
+            .to receive(:execute)
+                  .with(
+                    method:  :post,
+                    url:     "#{test_api_url}/PSD2/some/endpoint",
+                    payload: { :a => :b, :c => :d, :e => :f },
+                    timeout: 10
+                  )
+                  .and_call_original
+
+          api_call
+        end
       end
     end
   end

--- a/spec/afterbanks_psd2/resources/transaction_spec.rb
+++ b/spec/afterbanks_psd2/resources/transaction_spec.rb
@@ -21,6 +21,22 @@ describe AfterbanksPSD2::Transaction do
       )
     }
 
+    context "when the start_date is older than 90 days" do
+      let(:start_date) { Date.new(2020, 1, 1) }
+
+      it "increases the timeout to 2 hours" do
+        expect(RestClient::Request).to receive(:execute).with(
+          hash_including(
+            timeout: 7200
+          )
+        ).and_return(
+          double(body: '{}', headers: { debug_id: 'acclist1234' })
+        )
+
+        api_call
+      end
+    end
+
     context "when returning data" do
       before do
         stub_request(:post, "https://apipsd2.afterbanks.com/transactions/")


### PR DESCRIPTION
Context, Afterbanks support advices

> As you say, there is no pagination and in some cases the answer will be huge.
We have request execution timeouts set to 2 hours, so there is plenty of time to retrieve and return huge amounts of data.
We also have a response content size limite set to 2 GB so there is plenty of space for data.
By now, this settings are enough to handle all the requests we are receiving.
From your side you set your own limits, but you should be aware of these odd rare special cases, according to your customers banking profiles. If you work with home users you should expect few products and transactions. If your customers are big companies, you should expect large amounts of products and transactions.
We never interrupt requests and always give a single lined json response as big as needed to hold all the banking data.
Our customers set timeouts on their request waiting time, and sometimes they get to a client profile who needs to extend the limits.
We are in the middle of our customers and banks, and we have to get all the products and transactions to be able to give them to you. We do not store data and always send all the info as we retrieve it. If we allow to ask for pieces, we should store the data. If we would not store the data, we should then ask for the piece to the bank, what would need a new login each time to get that piece. For big accounts this would be a lot of logins, and then, bank would think of a brute force attack. You see?
This is the situation for V3 API banks. For PSD2 API banks there is a daily limit of 4 request per consent.
Best regards.

Increase timeout to `2 hours` for get transactions with more 3 months of historical

